### PR TITLE
Fix pgbouncer race condition, slightly clean code

### DIFF
--- a/server.go
+++ b/server.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+)
+
+type Server struct {
+	name      string
+	connstr   string
+	status    Status
+	lastcheck time.Time
+	laststate time.Time
+}
+
+func (server *Server) OpenConnection() (*sql.DB, error) {
+	db, err := sql.Open("postgres", fmt.Sprintf("%s connect_timeout=%d", server.connstr, config.getInt("global", "timeout", 3)-1))
+	if err != nil {
+		return db, err
+	}
+
+	db.SetMaxIdleConns(0)
+
+	err = db.Ping()
+	return db, err
+}
+
+// Check one server. Does not have timeout functionality, so the
+// calling function must take care of timeouts.
+func (server *Server) Check(retchan chan Status) {
+	db, err := server.OpenConnection()
+	defer AttemptClose(db)
+	if err != nil {
+		log.Printf("%s: failed to open connection: %s", server.name, err)
+		retchan <- DOWN
+		return
+	}
+
+	var inrecovery bool
+	err = db.QueryRow("SELECT pg_is_in_recovery()").Scan(&inrecovery)
+	if err != nil {
+		log.Printf("%s: query error: %s", server.name, err)
+		retchan <- DOWN
+		return
+	}
+
+	if inrecovery {
+		retchan <- STANDBY
+	} else {
+		retchan <- MASTER
+	}
+}
+
+// Check one server, timing out after 3 seconds or whatever is in the config.
+func (server *Server) CheckWithTimeout() {
+	timeout := time.After(time.Duration(config.getInt("global", "timeout", 3)) * time.Second)
+	retchan := make(chan Status, 1)
+
+	// Send the actual check
+	go server.Check(retchan)
+
+	select {
+	case status := <-retchan:
+		if server.status != status {
+			log.Printf("%s: now %v", server.name, status)
+			server.status = status
+			server.laststate = time.Now()
+		}
+	case <-timeout:
+		// Something timed out, so we're going to ignore the
+		// result and set this node as down.
+		if server.status != DOWN {
+			log.Printf("%s: timeout", server.name)
+			server.status = DOWN
+			server.laststate = time.Now()
+		}
+	}
+	server.lastcheck = time.Now()
+}
+
+// Actually reconfigure pgbouncer
+func (server *Server) MakeActiveMaster(pgbouncer *Server) {
+	// First connect to pgbouncer to make sure we can
+	bouncer, err := pgbouncer.OpenConnection()
+	defer AttemptClose(bouncer)
+	if err != nil {
+		log.Printf("PGBOUNCER: Could not connect - %s", err)
+		return
+	}
+
+	// Then flip the actual symlink
+	err = os.Remove(config["global"]["symlink"])
+	if err != nil {
+		log.Printf("ERROR: failed to remove old symlink: %s", err)
+		return
+	}
+
+	err = os.Symlink(fmt.Sprintf("%s/%s.ini", strings.TrimRight(config["global"]["configdir"], "/"), server.name), config["global"]["symlink"])
+	if err != nil {
+		log.Printf("ERROR: failed to set symlink for server %s: %s", server.name, err)
+		return
+	}
+
+	_, err = bouncer.Exec("RELOAD")
+	if err != nil {
+		log.Printf("ERROR: failed to reload pgbouncer: %s", err)
+		return
+	}
+
+	//Now that we've tried to turn over the master, we need to very rapidly determine if it worked and if not, RELOAD again.
+	aggressiveChecks = true
+
+	log.Printf("pgbouncer reconfigured for new master %s", server.name)
+}

--- a/status.go
+++ b/status.go
@@ -95,10 +95,10 @@ func httpNagiosHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func runHttpServer() {
+func runHTTPServer() error {
 	http.HandleFunc("/", httpRootHandler)
 	http.HandleFunc("/nodes", httpNodesHandler)
 	http.HandleFunc("/nagios", httpNagiosHandler)
 	log.Printf("Starting status http listener at http://%s", *listenAddr)
-	http.ListenAndServe(*listenAddr, nil)
+	return http.ListenAndServe(*listenAddr, nil)
 }


### PR DESCRIPTION
There is a problem with PGBouncer where occasionally, the RELOAD command will be called too quickly after changing the symlink, and pgbouncer will pull the old config file, failing to swap to the new master.  So, we now perform helath checks on pgbouncer itself, and when the master we're supposed to be using is live but the pgbouncer is not, we issue a new RELOAD command.  In order to ensure that Twitch's (very tight) recovery window is respected, we also put rebouncer into "aggressive mode" after a failover, checking every 100ms instead of the configured check window.  This continues until either the master dies or the pgbouncer comes live.  This should allow rebouncer to complete the failover within 100ms even when the initial RELOAD fails.

This added some complexity to the code and things started to unravel so I also performed some basic refactoring, moving the server concept (representing both the master/hotspares themselves but also the pgbouncer) to a separate file.
